### PR TITLE
Hiding password when inspecting

### DIFF
--- a/lib/vertica/connection.rb
+++ b/lib/vertica/connection.rb
@@ -129,6 +129,11 @@ class Vertica::Connection
     end
     return job.run
   end
+
+  def inspect
+    safe_options = @options.reject{ |name, _| name == :password }
+    "#<Vertica::Connection:#{object_id} @parameters=#{@parameters.inspect} @backend_pid=#{@backend_pid}, @backend_key=#{@backend_key}, @transaction_status=#{@transaction_status}, @socket=#{@socket}, @options=#{safe_options.inspect}, @row_style=#{@row_style}>"
+  end
   
   protected
   

--- a/test/functional/connection_test.rb
+++ b/test/functional/connection_test.rb
@@ -68,4 +68,10 @@ class ConnectionTest < Test::Unit::TestCase
       Vertica::Connection.new(TEST_CONNECTION_HASH.merge('database' => 'nonexistant_db'))
     end
   end
+
+  def test_connection_inspect_should_not_print_password
+    @connection = Vertica::Connection.new(TEST_CONNECTION_HASH)
+    inspected_string = @connection.inspect
+    assert_no_match /:password=>#{TEST_CONNECTION_HASH[:password]}/, inspected_string
+  end
 end


### PR DESCRIPTION
Better to avoid accidentally leaking clear passwords to a log file
