### PR TITLE
Make COPY commands leave the connection in a usable state if the block pushing data exceptions either in Ruby land or in the backend.

### DIFF
--- a/lib/vertica/connection.rb
+++ b/lib/vertica/connection.rb
@@ -179,7 +179,12 @@ class Vertica::Connection
   def run_with_mutex(job)
     boot_connection if closed?
     if @mutex.try_lock
-      job.run
+      begin
+        job.run
+      rescue StandardError
+        @mutex.unlock if @mutex.locked?
+        raise
+      end
     else
       raise Vertica::Error::SynchronizeError.new(job)
     end

--- a/lib/vertica/query.rb
+++ b/lib/vertica/query.rb
@@ -69,6 +69,8 @@ class Vertica::Query
         end
       rescue => e
         @connection.write_message Vertica::Messages::CopyFail.new(e.message)
+        process_message(@connection.read_message) # ErrorResponse
+        process_message(@connection.read_message) # ReadyForQuery
         raise
       end
     end


### PR DESCRIPTION
Before this, an unsuccessful COPY command didn't wait for the error message to come back or reset the mutex state upon an exception. This pops that message off the line so the next out going message doesn't get confused and resets the mutex so that the client code can try again!

@wvanbergen @sprsquish look ok to you folks? 
