### PR TITLE
[Bug Fix] force_encoding column name for multibyte letters

### DIFF
--- a/lib/vertica/column.rb
+++ b/lib/vertica/column.rb
@@ -49,7 +49,7 @@ module Vertica
       @type_modifier    = col[:type_modifier]
       @format           = col[:format_code] == 0 ? :text : :binary
       @table_oid        = col[:table_oid]
-      @name             = col[:name].to_sym
+      @name             = col[:name].force_encoding('UTF-8').to_sym
       @attribute_number = col[:attribute_number]
       @data_type        = DATA_TYPE_CONVERSIONS[col[:data_type_oid]][0]
       @converter        = DATA_TYPE_CONVERSIONS[col[:data_type_oid]][1]

--- a/lib/vertica/column.rb
+++ b/lib/vertica/column.rb
@@ -49,7 +49,7 @@ module Vertica
       @type_modifier    = col[:type_modifier]
       @format           = col[:format_code] == 0 ? :text : :binary
       @table_oid        = col[:table_oid]
-      @name             = col[:name].force_encoding('UTF-8').to_sym
+      @name             = col[:name].to_sym
       @attribute_number = col[:attribute_number]
       @data_type        = DATA_TYPE_CONVERSIONS[col[:data_type_oid]][0]
       @converter        = DATA_TYPE_CONVERSIONS[col[:data_type_oid]][1]

--- a/lib/vertica/messages/backend_messages/row_description.rb
+++ b/lib/vertica/messages/backend_messages/row_description.rb
@@ -12,7 +12,7 @@ module Vertica
         field_count.times do |field_index|
           field_info = data.unpack("@#{pos}Z*NnNnNn")
           @fields << {
-            :name             => field_info[0],
+            :name             => field_info[0].force_encoding('UTF-8'),
             :table_oid        => field_info[1],
             :attribute_number => field_info[2],
             :data_type_oid    => field_info[3],


### PR DESCRIPTION
hi @wvanbergen .
I'm @civitaspo. Nice to meet you.

So,

Our Vertica sometimes uses multibyte letters as column name .
In this case, this library cannot read the column name.

This pull Request fix that case.

[example:before](I hide host and password)

```
irb(main):001:0> require 'vertica'
=> true
irb(main):002:0> client = Vertica.connect(:host => 'example.com', :user => 'dbadmin', :password => 'secret', :database => 'vdb')
=> #<Vertica::Connection: ...secret...>
irb(main):003:0> client.query("select 'あ' as あ")
=> #<Vertica::Result:0x007fea39264fc8 @row_style=:hash, @rows=[{:"\xE3\x81\x82"=>"あ"}], @columns=[#<Vertica::Column:0x007fea392664b8 @type_modifier=7, @format=:text, @table_oid=0, @name=:"\xE3\x81\x82", @attribute_number=0, @data_type=:varchar, @converter=#<Proc:0x007fea39199788@/Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/column.rb:9 (lambda)>, @size=65535>], @tag="SELECT">
```

[example:after](I hide host and password)

```
irb(main):001:0> require 'vertica'
=> true
irb(main):002:0> client = Vertica.connect(:host => 'example.com', :user => 'dbadmin', :password => 'secret', :database => 'vdb')
=> #<Vertica::Connection: ...secret...>
irb(main):003:0> client.query("select 'あ' as あ")
=> #<Vertica::Result:0x007ff73a057628 @row_style=:hash, @rows=[{:あ=>"あ"}], @columns=[#<Vertica::Column:0x007ff73a056660 @type_modifier=7, @format=:text, @table_oid=0, @name=:あ, @attribute_number=0, @data_type=:varchar, @converter=#<Proc:0x007ff7399926f8@/Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/column.rb:9 (lambda)>, @size=65535>], @tag="SELECT">
```