### PR TITLE
Avoid Encoding::CompatibilityError

### DIFF
--- a/lib/vertica/error.rb
+++ b/lib/vertica/error.rb
@@ -23,7 +23,8 @@ class Vertica::Error < StandardError
     
     def initialize(error_response, sql)
       @error_response, @sql = error_response, sql
-      super("#{error_response.error_message}, SQL: #{one_line_sql.inspect}" )
+      super("#{error_response.error_message.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => '?')}, " + 
+            "SQL: #{one_line_sql.inspect.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => '?')}" )
     end
     
     def one_line_sql


### PR DESCRIPTION
Hi @wvanbergen 

After raising `Encoding::CompatibilityError` , the instance's status become strange(i think it's a bug).
So, I add the implementation that avoid this error(perhaps there may be a better solution...).

see below behaviours.

before:

```
irb(main):003:0> client.query("select あ")
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/error.rb:26:in `initialize'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/error.rb:35:in `new'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/error.rb:35:in `from_error_response'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/query.rb:44:in `process_message'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/query.rb:21:in `run'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):3
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
irb(main):004:0> client.query("select あ")
=> #<Vertica::Result:0x007f84058517f0 @row_style=:hash, @rows=[]>
irb(main):005:0> client.query("select a")
Vertica::Error::MissingColumn: Severity: ERROR, Message: Column "あ" does not exist, Sqlstate: 42703, Routine: transformColumnRef, File: parse_expr.c, Line: 1319, SQL: "select a"
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/query.rb:24:in `run'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):5
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
irb(main):006:0> client.query("select b")
Vertica::Error::MissingColumn: Severity: ERROR, Message: Column "a" does not exist, Sqlstate: 42703, Routine: transformColumnRef, File: parse_expr.c, Line: 1319, SQL: "select b"
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/query.rb:24:in `run'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/wvanbergen/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):6
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
```

after:

```
irb(main):003:0> client.query("select あ")
Vertica::Error::MissingColumn: Severity: ERROR, Message: Column "???" does not exist, Sqlstate: 42703, Routine: transformColumnRef, File: parse_expr.c, Line: 1319, SQL: "select あ"
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/query.rb:24:in `run'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):3
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
irb(main):004:0> client.query("select あ")
Vertica::Error::MissingColumn: Severity: ERROR, Message: Column "???" does not exist, Sqlstate: 42703, Routine: transformColumnRef, File: parse_expr.c, Line: 1319, SQL: "select あ"
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/query.rb:24:in `run'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):4
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
irb(main):005:0> client.query("select a")
Vertica::Error::MissingColumn: Severity: ERROR, Message: Column "a" does not exist, Sqlstate: 42703, Routine: transformColumnRef, File: parse_expr.c, Line: 1319, SQL: "select a"
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/query.rb:24:in `run'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):5
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
irb(main):006:0> client.query("select b")
Vertica::Error::MissingColumn: Severity: ERROR, Message: Column "b" does not exist, Sqlstate: 42703, Routine: transformColumnRef, File: parse_expr.c, Line: 1319, SQL: "select b"
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/query.rb:24:in `run'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:184:in `run_with_mutex'
        from /Users/takahiro.nakayama/src/github.com/civitaspo/vertica/lib/vertica/connection.rb:158:in `query'
        from (irb):6
        from /Users/takahiro.nakayama/.anyenv/envs/rbenv/versions/2.2.2/bin/irb:11:in `<main>'
```