### PR TITLE
Unescape VARBINARY values

### DIFF
--- a/lib/vertica/column.rb
+++ b/lib/vertica/column.rb
@@ -39,7 +39,7 @@ module Vertica
       [:interval,     nil],
       [:time_tz,      nil],
       [:numeric,      lambda { |s| BigDecimal.new(s) }],
-      [:bytea,        nil],
+      [:bytea,        lambda { |s| s.gsub(/(\\[0-3][0-7][0-7]|.)/) { |e| e.length == 4 ? [e[1..3].oct].pack('C') : e } }],
       [:rle_tuple,    nil]
     ]
 

--- a/test/functional/value_conversion_test.rb
+++ b/test/functional/value_conversion_test.rb
@@ -16,7 +16,8 @@ class ValueConversionTest < Minitest::Test
         "interval_field" interval,
         "boolean_field" boolean,
         "float_field" float,
-        "float_zero" float
+        "float_zero" float,
+        "binary_field" varbinary
       )
     SQL
   end
@@ -28,7 +29,7 @@ class ValueConversionTest < Minitest::Test
   end
   
   def test_value_conversions
-    @connection.query "INSERT INTO conversions_table VALUES (123, 'hello world', '2010-01-01', '2010-01-01 12:00:00', '12:00:00', INTERVAL '1 DAY', TRUE, 1.0, 0.0)"
+    @connection.query "INSERT INTO conversions_table VALUES (123, 'hello world', '2010-01-01', '2010-01-01 12:00:00', '12:00:00', INTERVAL '1 DAY', TRUE, 1.0, 0.0, HEX_TO_BINARY('d09fd180d0b8d0b2d0b5d1822c2068656c6c6f21'))"
     result = @connection.query "SELECT *,
                                        float_field / float_zero as infinity,
                                        float_field / float_zero - float_field / float_zero as nan
@@ -44,15 +45,16 @@ class ValueConversionTest < Minitest::Test
       true,
       1.0,
       0.0,
+      ['d09fd180d0b8d0b2d0b5d1822c2068656c6c6f21'].pack('H*'),
       Float::INFINITY,
       Float::NAN], result.rows.first
   end
   
   def test_nil_conversions
-    @connection.query "INSERT INTO conversions_table VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)"
+    @connection.query "INSERT INTO conversions_table VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)"
     result = @connection.query "SELECT * FROM conversions_table LIMIT 1"
     assert_equal result.rows.length, 1
-    assert_equal [nil, nil, nil, nil, nil, nil, nil, nil, nil], result.rows.first
+    assert_equal [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil], result.rows.first
   end
   
   def test_string_encoding


### PR DESCRIPTION
Seems like Vertica return VARBINARY data in escaped format (as in `vsql`):

```
ci=> SELECT HEX_TO_BINARY('d09fd180d0b8d0b2d0b5d1822c2068656c6c6f21');
                      HEX_TO_BINARY
----------------------------------------------------------
 \320\237\321\200\320\270\320\262\320\265\321\202, hello!
(1 row)
```

So, need to unescape (i.e. convert '\320' string to one byte equal to 0xD0) it to receive raw/original binary.

I think escaped string should contain only oct and visible ASCII characters as described [here](https://my.vertica.com/docs/7.1.x/HTML/Content/Authoring/AdministratorsGuide/BulkLoadCOPY/LoadingBinaryData.htm).

So, this is RP unescape binary value (i.e. convert escaped oct to characters and leave other characters). 

@wvanbergen What do you think?