### PR TITLE
Handle invalid unicode characters in SQL better

### DIFF
--- a/lib/vertica/error.rb
+++ b/lib/vertica/error.rb
@@ -24,11 +24,12 @@ class Vertica::Error < StandardError
 
     def initialize(error_response, sql)
       @error_response, @sql = error_response, sql
-      super("#{error_response.error_message}, SQL: #{one_line_sql.inspect}" )
+      utf8_encoded_error = error_response.error_message.encode('utf-8', :invalid => :replace, :undef => :replace)
+      super("#{utf8_encoded_error}, SQL: #{one_line_sql.inspect}" )
     end
 
     def one_line_sql
-      @sql.gsub(/[\r\n]+/, ' ')
+      @sql.to_s.encode('utf-8', :invalid => :replace, :undef => :replace).gsub(/[\r\n]+/, ' ')
     end
 
     def self.from_error_response(error_response, sql)

--- a/lib/vertica/query.rb
+++ b/lib/vertica/query.rb
@@ -7,7 +7,7 @@ class Vertica::Query
     @connection, @sql = connection, sql
     
     @row_style    = options[:row_style] || @connection.row_style || :hash
-    @row_handler  = options[:row_handler] 
+    @row_handler  = options[:row_handler]
     @copy_handler = options[:copy_handler]
 
     @error  = nil
@@ -15,8 +15,8 @@ class Vertica::Query
   end
 
   def run
-    @connection.write_message Vertica::Messages::Query.new(sql)
-    
+    @connection.write_message(Vertica::Messages::Query.new(sql))
+
     begin
       process_message(message = @connection.read_message)
     end until message.kind_of?(Vertica::Messages::ReadyForQuery)
@@ -24,20 +24,20 @@ class Vertica::Query
     raise error unless error.nil?
     return result
   end
-  
+
   def write(data)
-    @connection.write_message Vertica::Messages::CopyData.new(data)
+    @connection.write_message(Vertica::Messages::CopyData.new(data))
     return self
   end
-  
+
   alias_method :<<, :write
 
   def to_s
     @sql
   end
-  
+
   protected
-  
+
   def process_message(message)
     case message
     when Vertica::Messages::ErrorResponse
@@ -56,19 +56,19 @@ class Vertica::Query
       @connection.process_message(message)
     end
   end
-  
+
   def handle_copy_from_stdin
     if copy_handler.nil?
-      @connection.write_message Vertica::Messages::CopyFail.new('no handler provided')
+      @connection.write_message(Vertica::Messages::CopyFail.new('no handler provided'))
     else
       begin
         if copy_handler.call(self) == :rollback
-          @connection.write_message Vertica::Messages::CopyFail.new("rollback")
+          @connection.write_message(Vertica::Messages::CopyFail.new("rollback"))
         else
-          @connection.write_message Vertica::Messages::CopyDone.new
+          @connection.write_message(Vertica::Messages::CopyDone.new)
         end
       rescue => e
-        @connection.write_message Vertica::Messages::CopyFail.new(e.message)
+        @connection.write_message(Vertica::Messages::CopyFail.new(e.message))
       end
     end
   end
@@ -78,7 +78,7 @@ class Vertica::Query
     result.add_row(record) if buffer_rows?
     row_handler.call(record) if row_handler
   end
-  
+
   def buffer_rows?
     row_handler.nil? && copy_handler.nil?
   end


### PR DESCRIPTION
This will make sure we don't raise encoding exceptions, and make sure the connection is not broken after dealing with encoding issues.

However, this does mean that we return values that are invalid unicode (see the added test, `"\xA4\xA2"` is not a valid unicode string). It looks like Vertica is quite forgiving when it comes to that.

The alternative that code work is that we only accept unicode strings as SQL, and immediately raise an exception if a string cannot be transcoded to UTF-8.

@civitaspo @maxd @bicyclethief Any thoughts on what the best way to deal with this scenario is?