### PR TITLE
Cleanup connection interrupting

### DIFF
--- a/lib/vertica/connection.rb
+++ b/lib/vertica/connection.rb
@@ -6,10 +6,6 @@ class Vertica::Connection
 
   attr_reader :options
 
-  def self.cancel(existing_conn)
-    existing_conn.cancel
-  end
-
   # Opens a connectio the a Vertica server
   # @param [Hash] options The connection options to use.
   def initialize(host: nil, port: 5433, username: nil, password: nil, database: nil, interruptable: false, ssl: nil, read_timeout: 600, debug: false, role: nil, search_path: nil, timezone: nil, autocommit: false, skip_startup: false, skip_initialize: false, user: nil)

--- a/test/functional/functional_connection_test.rb
+++ b/test/functional/functional_connection_test.rb
@@ -27,6 +27,11 @@ class FunctionalConnectionTest < Minitest::Test
     assert connection.interruptable?, "The connection should be interruptable!"
   end
 
+  def test_interrupt_on_non_interruptable_connection
+    connection = Vertica::Connection.new(interruptable: false, **TEST_CONNECTION_HASH)
+    assert_raises(Vertica::Error::InterruptImpossible) { connection.interrupt }
+  end
+
   def test_new_with_error_response
     assert_raises(Vertica::Error::ConnectionError) do
       Vertica::Connection.new(TEST_CONNECTION_HASH.merge(database: 'nonexistant_db'))


### PR DESCRIPTION
- Cleanup code for `Connection#intterupt`, add test for non-interruptible connections.
- Remove `Connection.cancel(conn)`; use `Connection#cancel` instead. 