### PR TITLE
Hide internal state of a connection

### DIFF
--- a/lib/vertica/connection.rb
+++ b/lib/vertica/connection.rb
@@ -2,9 +2,7 @@ require 'socket'
 
 class Vertica::Connection
 
-  attr_reader :transaction_status, :backend_pid, :backend_key, :parameters, :notice_handler, :session_id
-
-  attr_reader :options
+  attr_reader :transaction_status, :parameters, :options
 
   # Opens a connectio the a Vertica server
   # @param [Hash] options The connection options to use.
@@ -147,6 +145,8 @@ class Vertica::Connection
   end
 
   protected
+
+  attr_reader :backend_pid, :backend_key,  :session_id
 
   def socket
     @socket ||= begin

--- a/test/functional/functional_connection_test.rb
+++ b/test/functional/functional_connection_test.rb
@@ -162,8 +162,6 @@ class FunctionalConnectionTest < Minitest::Test
     refute connection.closed?
 
     # connection variables
-    assert connection.backend_pid
-    assert connection.backend_key
     assert connection.transaction_status
 
     # parameters
@@ -175,8 +173,6 @@ class FunctionalConnectionTest < Minitest::Test
     refute connection.opened?
     assert connection.closed?
     assert_equal({}, connection.parameters)
-    assert_nil connection.backend_pid
-    assert_nil connection.backend_key
     assert_nil connection.transaction_status
   end
 end


### PR DESCRIPTION
No need to expose this as part of the API.